### PR TITLE
HOCS-2576: Drone V1 Migration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,185 +1,244 @@
-pipeline:
+---
 
-  build-project:
-    image: quay.io/ukhomeofficedigital/openjdk11:v11.0.5_10
-    commands:
-      - ./gradlew build
-    when:
-      event: [push, pull_request, tag]
+kind: pipeline
+type: kubernetes
+name: build
 
-  sonar-scanner:
-    image: quay.io/ukhomeofficedigital/sonar-scanner:v3.0.3
-    when:
-      event: [push, pull_request, tag]
+steps:
+- name: build project
+  image: quay.io/ukhomeofficedigital/openjdk11:v11.0.5_10
+  commands:
+  - ./gradlew build
+  when:
+    event:
+      - push
 
-  docker-build:
-    image: docker:17.09.1
-    environment:
-      - DOCKER_HOST=tcp://172.17.0.1:2375
-    commands:
-      - docker build -t hocs-templates .
-    when:
-      branch: [master, refs/tags/*]
-      event: [push, tag]
+- name: sonar scanner
+  image: quay.io/ukhomeofficedigital/sonar-scanner:v3.0.3
+  when:
+    event:
+      - push
+  depends_on:
+    - build project
 
-  install-docker-image:
-    image: docker:17.09.1
-    environment:
-      - DOCKER_HOST=tcp://172.17.0.1:2375
-    secrets:
-      - docker_password
-    commands:
-      - docker login -u="ukhomeofficedigital+hocs" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag hocs-templates quay.io/ukhomeofficedigital/hocs-templates:build-$${DRONE_BUILD_NUMBER}
-      - docker tag hocs-templates quay.io/ukhomeofficedigital/hocs-templates:latest
-      - docker push quay.io/ukhomeofficedigital/hocs-templates:build-$${DRONE_BUILD_NUMBER}
-      - docker push quay.io/ukhomeofficedigital/hocs-templates:latest
-    when:
-      branch: master
-      event: push
+- name: build & push
+  image: plugins/docker
+  settings:
+    registry: quay.io
+    repo: quay.io/ukhomeofficedigital/hocs-templates
+    tags:
+      - build_${DRONE_BUILD_NUMBER}
+      - ${DRONE_COMMIT_SHA}
+      - branch-${DRONE_COMMIT_BRANCH/\//_}
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: QUAY_ROBOT_PASSWORD
+    DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
+  when:
+    event:
+      - push
+  depends_on:
+    - build project
 
-  docker-semver-tag:
-    image: quay.io/ukhomeofficedigital/hocs-version-bot:build-25
-    environment:
-      - DOCKER_HOST=tcp://172.17.0.1:2375
-      - DOCKER_API_VERSION=1.37
-    secrets:
-      - github_password
-      - docker_password
-      - git_password
-    commands:
-      - /app/hocs-deploy --version=$${SEMVER} --serviceGitToken=$${GIT_PASSWORD} --service=hocs-templates --gitToken=$${GITHUB_PASSWORD} --gitRepo="https://gitlab.digital.homeoffice.gov.uk/hocs/hocs-versions.git" --environment=qa --dockerRepository=quay.io/ukhomeofficedigital --sourceBuild=$${IMAGE_VERSION} --registryUser=ukhomeofficedigital+hocs --registryPassword=$${DOCKER_PASSWORD}
-    when:
-      event: deployment
-      environment: [cs-qa, wcs-qa, hocs-qax]
+- name: build & push latest
+  image: plugins/docker
+  settings:
+    registry: quay.io
+    repo: quay.io/ukhomeofficedigital/hocs-templates
+    tags:
+      - master
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: QUAY_ROBOT_PASSWORD
+    DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
+  when:
+    branch:
+      - master
+    event:
+      - push
+  depends_on:
+    - build project
 
-  clone-kube-project:
-    image: plugins/git
-    commands:
-      - git clone https://github.com/UKHomeOffice/kube-hocs-templates.git
-    when:
-      event: [push, tag, deployment]
+trigger:
+  event:
+    - push
 
+---
 
-  deploy-to-cs-dev-from-build-number:
-    image: quay.io/ukhomeofficedigital/kd:v1.16.0
-    environment:
-      - ENVIRONMENT=cs-dev
-      - VERSION=build-${DRONE_BUILD_NUMBER}
-      - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-    secrets:
-      - hocs_templates_cs_dev
-    commands:
-      - cd kube-hocs-templates
-      - ./deploy.sh
-    when:
-      branch: master
-      event: [push, tag]
+kind: pipeline
+type: kubernetes
+name: deploy
+depends_on:
+  - build
 
-  deploy-to-wcs-dev-from-build-number:
-    image: quay.io/ukhomeofficedigital/kd:v1.16.0
-    environment:
-      - ENVIRONMENT=wcs-dev
-      - VERSION=build-${DRONE_BUILD_NUMBER}
-      - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-    secrets:
-      - hocs_templates_wcs_dev
-    commands:
-      - cd kube-hocs-templates
-      - ./deploy.sh
-    when:
-      branch: master
-      event: [push, tag]
+steps:
+- name: clone kube repo
+  image: plugins/git
+  commands:
+    - git clone https://github.com/UKHomeOffice/kube-hocs-templates.git
+  when:
+    event:
+      - push
+      - promote
 
-  deployment:
-    image: quay.io/ukhomeofficedigital/kd:v1.16.0
-    environment:
-      - ENVIRONMENT=${DRONE_DEPLOY_TO}
-      - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-    secrets:
-      - hocs_templates_cs_dev
-      - hocs_templates_cs_demo
-      - hocs_templates_wcs_dev
-      - hocs_templates_wcs_demo
-    commands:
-      - cd kube-hocs-templates
-      - ./deploy.sh
-    when:
-      event: deployment
-      environment: [cs-dev, cs-demo, wcs-dev, wcs-demo]
+- name: deploy to cs-dev
+  image: quay.io/ukhomeofficedigital/kd:v1.16.0
+  commands:
+    - cd kube-hocs-templates
+    - ./deploy.sh
+  environment:
+    ENVIRONMENT: cs-dev
+    KUBE_TOKEN:
+      from_secret: hocs_templates_cs_dev
+    KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+    VERSION: build-${DRONE_BUILD_NUMBER}
+  when:
+    branch:
+      - master
+    event:
+      - push
+  depends_on:
+    - clone kube repo
 
-  deploy-to-cs-qa:
-    image: quay.io/ukhomeofficedigital/kd:v1.16.0
-    environment:
-      - ENVIRONMENT=cs-qa
-      - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-    secrets:
-      - hocs_templates_cs_qa
-    commands:
-      - source version.txt
-      - echo $VERSION
-      - cd kube-hocs-templates
-      - ./deploy.sh
-    when:
-      event: deployment
-      environment: cs-qa
+- name: deploy to wcs-dev
+  image: quay.io/ukhomeofficedigital/kd:v1.16.0
+  commands:
+    - cd kube-hocs-templates
+    - ./deploy.sh
+  environment:
+    ENVIRONMENT: wcs-dev
+    KUBE_TOKEN:
+      from_secret: hocs_templates_wcs_dev
+    KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+    VERSION: build-${DRONE_BUILD_NUMBER}
+  when:
+    branch:
+      - master
+    event:
+      - push
+  depends_on:
+    - clone kube repo
 
-  deploy-to-wcs-qa:
-    image: quay.io/ukhomeofficedigital/kd:v1.16.0
-    environment:
-      - ENVIRONMENT=wcs-qa
-      - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-    secrets:
-      - hocs_templates_wcs_qa
-    commands:
-      - source version.txt
-      - echo $VERSION
-      - cd kube-hocs-templates
-      - ./deploy.sh
-    when:
-      event: deployment
-      environment: wcs-qa
+- name: generate & tag build
+  image: quay.io/ukhomeofficedigital/hocs-version-bot:latest
+  commands:
+    - >
+      /app/hocs-deploy
+      --dockerRepository=quay.io/ukhomeofficedigital
+      --environment=qa
+      --registryPassword=$${DOCKER_PASSWORD}
+      --registryUser=ukhomeofficedigital+hocs_quay_robot
+      --service=${SERVICE}
+      --serviceGitToken=$${GITHUB_TOKEN}
+      --sourceBuild=$${IMAGE_VERSION}
+      --version=$${SEMVER}
+      --versionRepo="https://gitlab.digital.homeoffice.gov.uk/hocs/hocs-versions.git"
+      --versionRepoServiceToken=$${GITLAB_TOKEN}
+  environment:
+    DOCKER_PASSWORD:
+      from_secret: QUAY_ROBOT_PASSWORD
+    GITLAB_TOKEN:
+      from_secret: GITLAB_TOKEN
+    GITHUB_TOKEN:
+      from_secret: GITHUB_TOKEN
+  when:
+    event:
+      - promote
+    target:
+      - release
 
-  deploy-to-hocs-qax:
-    image: quay.io/ukhomeofficedigital/kd:v1.16.0
-    environment:
-      - ENVIRONMENT=hocs-qax
-      - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-    secrets:
-      - hocs_templates_qax
-    commands:
-      - source version.txt
-      - echo $VERSION
-      - cd kube-hocs-templates
-      - ./deploy.sh
-    when:
-      event: deployment
-      environment: hocs-qax
+- name: deploy to cs-qa
+  image: quay.io/ukhomeofficedigital/kd:v1.16.0
+  commands:
+    - source version.txt
+    - echo $VERSION
+    - cd kube-hocs-templates
+    - ./deploy.sh
+  environment:
+    ENVIRONMENT: cs-qa
+    KUBE_TOKEN:
+      from_secret: hocs_templates_cs_qa
+    KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+  when:
+    event:
+      - promote
+    target:
+      - release
+  depends_on:
+    - clone kube repo
+    - generate & tag build
 
-  deploy-to-cs-prod:
-    image: quay.io/ukhomeofficedigital/kd:v1.16.0
-    environment:
-      - ENVIRONMENT=cs-prod
-      - KUBE_SERVER=https://kube-api-prod.prod.acp.homeoffice.gov.uk
-    secrets:
-      - hocs_templates_cs_prod
-    commands:
-      - cd kube-hocs-templates
-      - ./deploy.sh
-    when:
-      event: deployment
-      environment: cs-prod
+- name: deploy to wcs-qa
+  image: quay.io/ukhomeofficedigital/kd:v1.16.0
+  commands:
+    - source version.txt
+    - echo $VERSION
+    - cd kube-hocs-templates
+    - ./deploy.sh
+  environment:
+    ENVIRONMENT: wcs-qa
+    KUBE_TOKEN:
+      from_secret: hocs_templates_wcs_qa
+    KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+  when:
+    event:
+      - promote
+    target:
+      - release
+  depends_on:
+    - clone kube repo
+    - generate & tag build
 
-  deploy-to-wcs-prod:
-    image: quay.io/ukhomeofficedigital/kd:v1.16.0
-    environment:
-      - ENVIRONMENT=wcs-prod
-      - KUBE_SERVER=https://kube-api-prod.prod.acp.homeoffice.gov.uk
-    secrets:
-      - hocs_templates_wcs_prod
-    commands:
-      - cd kube-hocs-templates
-      - ./deploy.sh
-    when:
-      event: deployment
-      environment: wcs-prod
+- name: deploy to not prod 
+  image: quay.io/ukhomeofficedigital/kd:v1.16.0
+  commands:
+    - cd kube-hocs-templates
+    - ./deploy.sh
+  environment:
+    ENVIRONMENT: ${DRONE_DEPLOY_TO}
+    KUBE_TOKEN:
+      from_secret: hocs_templates_${DRONE_DEPLOY_TO/-/_}
+    KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+  when:
+    event:
+      - promote
+    target:
+      exclude:
+        - release
+        - cs-prod
+        - wcs-prod
+  depends_on:
+    - clone kube repo
+
+- name: deploy to prod
+  image: quay.io/ukhomeofficedigital/kd:v1.16.0
+  commands:
+    - cd kube-hocs-templates
+    - ./deploy.sh
+  environment:
+    ENVIRONMENT: ${DRONE_DEPLOY_TO}
+    KUBE_TOKEN:
+      from_secret: hocs_templates_${DRONE_DEPLOY_TO/-/_}
+    KUBE_SERVER: https://kube-api-prod.prod.acp.homeoffice.gov.uk
+  when:
+    event:
+      - promote
+    target:
+      - cs-prod
+      - wcs-prod
+  depends_on:
+    - clone kube repo
+
+trigger:
+  event:
+    - promote
+
+trigger:
+  event:
+    - push
+  branch:
+    include:
+      - master
+      - epic/*
+
+...


### PR DESCRIPTION
As part of the decommissioning of Drone V0.8 we need to migrate to Drone V1. 

The following changes have been implemented: 
- Conversion of the Drone yaml script to use latest standard.
- New secret names to resemble what they actually mean
- Change to use latest hocs-version-bot and correct the parameters passed in