### PR TITLE
Add event to deploy trigger

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -60,9 +60,10 @@ name: deploy
 depends_on:
   - build
 trigger:
-  exclude:
-    - pull_request
-    - tag
+  event:
+    exclude:
+      - pull_request
+      - tag
 
 services:
   - name: docker


### PR DESCRIPTION
At present the trigger for deployment is missing 
what it should exclude - in this case the event. 
Therefore, the exclude is not working as intended. 
This change adds this in so it will exclude this.