### PR TITLE
HOCS-2576: genericise not prod excludes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -219,8 +219,7 @@ steps:
     target:
       exclude:
         - release
-        - cs-prod
-        - wcs-prod
+        - "*-prod"
   depends_on:
     - clone kube repo
 


### PR DESCRIPTION
At present we only stop releases to cs-prod and 
wcs-prod. If we ever have any more prod envs 
this would need updating. This change genericises 
this.