### PR TITLE
HOCS-2576: generalise prod deployment

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -237,8 +237,8 @@ steps:
     event:
       - promote
     target:
-      - cs-prod
-      - wcs-prod
+      include:
+        - "*-prod"
   depends_on:
     - clone kube repo
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,7 +26,7 @@ steps:
       - branch-${DRONE_COMMIT_BRANCH/\//_}
   environment:
     DOCKER_PASSWORD:
-      from_secret: QUAY_ROBOT_PASSWORD
+      from_secret: QUAY_ROBOT_TOKEN
     DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
   depends_on:
     - build project
@@ -40,7 +40,7 @@ steps:
       - latest
   environment:
     DOCKER_PASSWORD:
-      from_secret: QUAY_ROBOT_PASSWORD
+      from_secret: QUAY_ROBOT_TOKEN
     DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
   when:
     branch:
@@ -148,7 +148,7 @@ steps:
   environment:
     DOCKER_API_VERSION: 1.40
     DOCKER_PASSWORD:
-      from_secret: QUAY_ROBOT_PASSWORD
+      from_secret: QUAY_ROBOT_TOKEN
     GITLAB_TOKEN:
       from_secret: GITLAB_TOKEN
     GITHUB_TOKEN:


### PR DESCRIPTION
At present we only allow for deployment to production environments that
are either `cs-prod` or `wcs-prod`. This change allows to release to any 
prod environment specified.