### PR TITLE
HOCS-2576: consolidate version parameter

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -141,7 +141,7 @@ steps:
       --registryUser=ukhomeofficedigital+hocs_quay_robot
       --service=hocs-templates
       --serviceGitToken=$${GITHUB_TOKEN}
-      --sourceBuild=$${IMAGE_VERSION}
+      --sourceBuild=$${VERSION}
       --version=$${SEMVER}
       --versionRepo="https://gitlab.digital.homeoffice.gov.uk/hocs/hocs-versions.git"
       --versionRepoServiceToken=$${GITLAB_TOKEN}


### PR DESCRIPTION
Currently we have `VERSION` and `IMAGE_VERSION` that are both
used interchangeably. To consolidate this, `VERSION` is now the decided 
parameter to use.