### PR TITLE
HOCS-2576: split build step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,14 @@ steps:
   - name: build project
     image: quay.io/ukhomeofficedigital/openjdk11:v11.0.5_10
     commands:
-      - ./gradlew build
+      - ./gradlew assemble --no-daemon
+
+  - name: test project
+    image: quay.io/ukhomeofficedigital/openjdk11:v11.0.5_10
+    commands:
+      - ./gradlew check --no-daemon
+    depends_on:
+      - build project
 
   - name: sonar scanner
     image: quay.io/ukhomeofficedigital/sonar-scanner:v3.0.3
@@ -28,7 +35,7 @@ steps:
         from_secret: QUAY_ROBOT_TOKEN
       DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
     depends_on:
-      - build project
+      - test project
 
   - name: build & push latest
     image: plugins/docker
@@ -45,7 +52,7 @@ steps:
       branch:
         - main
     depends_on:
-      - build project
+      - test project
 
 trigger:
   event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,59 +1,57 @@
 ---
-
 kind: pipeline
 type: kubernetes
 name: build
 
 steps:
-- name: build project
-  image: quay.io/ukhomeofficedigital/openjdk11:v11.0.5_10
-  commands:
-  - ./gradlew build
+  - name: build project
+    image: quay.io/ukhomeofficedigital/openjdk11:v11.0.5_10
+    commands:
+      - ./gradlew build
 
-- name: sonar scanner
-  image: quay.io/ukhomeofficedigital/sonar-scanner:v3.0.3
-  depends_on:
-    - build project
+  - name: sonar scanner
+    image: quay.io/ukhomeofficedigital/sonar-scanner:v3.0.3
+    depends_on:
+      - build project
 
-- name: build & push
-  image: plugins/docker
-  settings:
-    registry: quay.io
-    repo: quay.io/ukhomeofficedigital/hocs-templates
-    tags:
-      - build_${DRONE_BUILD_NUMBER}
-      - ${DRONE_COMMIT_SHA}
-      - branch-${DRONE_COMMIT_BRANCH/\//_}
-  environment:
-    DOCKER_PASSWORD:
-      from_secret: QUAY_ROBOT_TOKEN
-    DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
-  depends_on:
-    - build project
+  - name: build & push
+    image: plugins/docker
+    settings:
+      registry: quay.io
+      repo: quay.io/ukhomeofficedigital/hocs-templates
+      tags:
+        - build_${DRONE_BUILD_NUMBER}
+        - ${DRONE_COMMIT_SHA}
+        - branch-${DRONE_COMMIT_BRANCH/\//_}
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: QUAY_ROBOT_TOKEN
+      DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
+    depends_on:
+      - build project
 
-- name: build & push latest
-  image: plugins/docker
-  settings:
-    registry: quay.io
-    repo: quay.io/ukhomeofficedigital/hocs-templates
-    tags:
-      - latest
-  environment:
-    DOCKER_PASSWORD:
-      from_secret: QUAY_ROBOT_TOKEN
-    DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
-  when:
-    branch:
-      - main
-  depends_on:
-    - build project
+  - name: build & push latest
+    image: plugins/docker
+    settings:
+      registry: quay.io
+      repo: quay.io/ukhomeofficedigital/hocs-templates
+      tags:
+        - latest
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: QUAY_ROBOT_TOKEN
+      DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
+    when:
+      branch:
+        - main
+    depends_on:
+      - build project
 
 trigger:
   event:
     - push
 
 ---
-
 kind: pipeline
 type: kubernetes
 name: deploy
@@ -73,173 +71,171 @@ environment:
   DOCKER_HOST: tcp://docker:2375
 
 steps:
-- name: clone kube repo
-  image: plugins/git
-  commands:
-    - git clone https://github.com/UKHomeOffice/kube-hocs-templates.git
-  when:
-    event:
-      - push
-      - promote
+  - name: clone kube repo
+    image: plugins/git
+    commands:
+      - git clone https://github.com/UKHomeOffice/kube-hocs-templates.git
+    when:
+      event:
+        - push
+        - promote
 
-- name: deploy to cs-dev
-  image: quay.io/ukhomeofficedigital/kd:v1.16.0
-  commands:
-    - cd kube-hocs-templates
-    - ./deploy.sh
-  environment:
-    ENVIRONMENT: cs-dev
-    KUBE_TOKEN:
-      from_secret: hocs_templates_cs_dev
-    KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-    VERSION: build_${DRONE_BUILD_NUMBER}
-  when:
-    branch:
-      - main
-    event:
-      - push
-  depends_on:
-    - clone kube repo
+  - name: deploy to cs-dev
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    commands:
+      - cd kube-hocs-templates
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: cs-dev
+      KUBE_TOKEN:
+        from_secret: hocs_templates_cs_dev
+      KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+      VERSION: build_${DRONE_BUILD_NUMBER}
+    when:
+      branch:
+        - main
+      event:
+        - push
+    depends_on:
+      - clone kube repo
 
-- name: deploy to wcs-dev
-  image: quay.io/ukhomeofficedigital/kd:v1.16.0
-  commands:
-    - cd kube-hocs-templates
-    - ./deploy.sh
-  environment:
-    ENVIRONMENT: wcs-dev
-    KUBE_TOKEN:
-      from_secret: hocs_templates_wcs_dev
-    KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-    VERSION: build_${DRONE_BUILD_NUMBER}
-  when:
-    branch:
-      - main
-    event:
-      - push
-  depends_on:
-    - clone kube repo
+  - name: deploy to wcs-dev
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    commands:
+      - cd kube-hocs-templates
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: wcs-dev
+      KUBE_TOKEN:
+        from_secret: hocs_templates_wcs_dev
+      KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+      VERSION: build_${DRONE_BUILD_NUMBER}
+    when:
+      branch:
+        - main
+      event:
+        - push
+    depends_on:
+      - clone kube repo
 
-- name: wait for docker
-  image: docker
-  commands:
-    - n=0; until docker stats --no-stream; do echo "Waiting for Docker $n"; n=$((n +1)); sleep 1; done
-  when:
-    event:
-      - promote
-    target:
-      - release
-
-- name: generate & tag build
-  image: quay.io/ukhomeofficedigital/hocs-version-bot:latest
-  commands:
-    - >
-      /app/hocs-deploy
-      --dockerRepository=quay.io/ukhomeofficedigital
-      --environment=qa
-      --registryPassword=$${DOCKER_PASSWORD}
-      --registryUser=ukhomeofficedigital+hocs_quay_robot
-      --service=hocs-templates
-      --serviceGitToken=$${GITHUB_TOKEN}
-      --sourceBuild=$${VERSION}
-      --version=$${SEMVER}
-      --versionRepo="https://gitlab.digital.homeoffice.gov.uk/hocs/hocs-versions.git"
-      --versionRepoServiceToken=$${GITLAB_TOKEN}
-  environment:
-    DOCKER_API_VERSION: 1.40
-    DOCKER_PASSWORD:
-      from_secret: QUAY_ROBOT_TOKEN
-    GITLAB_TOKEN:
-      from_secret: GITLAB_TOKEN
-    GITHUB_TOKEN:
-      from_secret: GITHUB_TOKEN
-  depends_on:
-    - wait for docker
-  when:
-    event:
-      - promote
-    target:
-      - release
-
-- name: deploy to cs-qa
-  image: quay.io/ukhomeofficedigital/kd:v1.16.0
-  commands:
-    - source version.txt
-    - echo $VERSION
-    - cd kube-hocs-templates
-    - ./deploy.sh
-  environment:
-    ENVIRONMENT: cs-qa
-    KUBE_TOKEN:
-      from_secret: hocs_templates_cs_qa
-    KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-  when:
-    event:
-      - promote
-    target:
-      - release
-  depends_on:
-    - clone kube repo
-    - generate & tag build
-
-- name: deploy to wcs-qa
-  image: quay.io/ukhomeofficedigital/kd:v1.16.0
-  commands:
-    - source version.txt
-    - echo $VERSION
-    - cd kube-hocs-templates
-    - ./deploy.sh
-  environment:
-    ENVIRONMENT: wcs-qa
-    KUBE_TOKEN:
-      from_secret: hocs_templates_wcs_qa
-    KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-  when:
-    event:
-      - promote
-    target:
-      - release
-  depends_on:
-    - clone kube repo
-    - generate & tag build
-
-- name: deploy to not prod 
-  image: quay.io/ukhomeofficedigital/kd:v1.16.0
-  commands:
-    - cd kube-hocs-templates
-    - ./deploy.sh
-  environment:
-    ENVIRONMENT: ${DRONE_DEPLOY_TO}
-    KUBE_TOKEN:
-      from_secret: hocs_templates_${DRONE_DEPLOY_TO/-/_}
-    KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-  when:
-    event:
-      - promote
-    target:
-      exclude:
+  - name: wait for docker
+    image: docker
+    commands:
+      - n=0; until docker stats --no-stream; do echo "Waiting for Docker $n"; n=$((n +1)); sleep 1; done
+    when:
+      event:
+        - promote
+      target:
         - release
-        - "*-prod"
-  depends_on:
-    - clone kube repo
 
-- name: deploy to prod
-  image: quay.io/ukhomeofficedigital/kd:v1.16.0
-  commands:
-    - cd kube-hocs-templates
-    - ./deploy.sh
-  environment:
-    ENVIRONMENT: ${DRONE_DEPLOY_TO}
-    KUBE_TOKEN:
-      from_secret: hocs_templates_${DRONE_DEPLOY_TO/-/_}
-    KUBE_SERVER: https://kube-api-prod.prod.acp.homeoffice.gov.uk
-  when:
-    event:
-      - promote
-    target:
-      include:
-        - "*-prod"
-  depends_on:
-    - clone kube repo
+  - name: generate & tag build
+    image: quay.io/ukhomeofficedigital/hocs-version-bot:latest
+    commands:
+      - >
+        /app/hocs-deploy
+        --dockerRepository=quay.io/ukhomeofficedigital
+        --environment=qa
+        --registryPassword=$${DOCKER_PASSWORD}
+        --registryUser=ukhomeofficedigital+hocs_quay_robot
+        --service=hocs-templates
+        --serviceGitToken=$${GITHUB_TOKEN}
+        --sourceBuild=$${VERSION}
+        --version=$${SEMVER}
+        --versionRepo="https://gitlab.digital.homeoffice.gov.uk/hocs/hocs-versions.git"
+        --versionRepoServiceToken=$${GITLAB_TOKEN}
+    environment:
+      DOCKER_API_VERSION: 1.40
+      DOCKER_PASSWORD:
+        from_secret: QUAY_ROBOT_TOKEN
+      GITLAB_TOKEN:
+        from_secret: GITLAB_TOKEN
+      GITHUB_TOKEN:
+        from_secret: GITHUB_TOKEN
+    depends_on:
+      - wait for docker
+    when:
+      event:
+        - promote
+      target:
+        - release
 
-...
+  - name: deploy to cs-qa
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    commands:
+      - source version.txt
+      - echo $VERSION
+      - cd kube-hocs-templates
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: cs-qa
+      KUBE_TOKEN:
+        from_secret: hocs_templates_cs_qa
+      KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+    when:
+      event:
+        - promote
+      target:
+        - release
+    depends_on:
+      - clone kube repo
+      - generate & tag build
+
+  - name: deploy to wcs-qa
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    commands:
+      - source version.txt
+      - echo $VERSION
+      - cd kube-hocs-templates
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: wcs-qa
+      KUBE_TOKEN:
+        from_secret: hocs_templates_wcs_qa
+      KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+    when:
+      event:
+        - promote
+      target:
+        - release
+    depends_on:
+      - clone kube repo
+      - generate & tag build
+
+  - name: deploy to not prod
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    commands:
+      - cd kube-hocs-templates
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: ${DRONE_DEPLOY_TO}
+      KUBE_TOKEN:
+        from_secret: hocs_templates_${DRONE_DEPLOY_TO/-/_}
+      KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+    when:
+      event:
+        - promote
+      target:
+        exclude:
+          - release
+          - "*-prod"
+    depends_on:
+      - clone kube repo
+
+  - name: deploy to prod
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    commands:
+      - cd kube-hocs-templates
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: ${DRONE_DEPLOY_TO}
+      KUBE_TOKEN:
+        from_secret: hocs_templates_${DRONE_DEPLOY_TO/-/_}
+      KUBE_SERVER: https://kube-api-prod.prod.acp.homeoffice.gov.uk
+    when:
+      event:
+        - promote
+      target:
+        include:
+          - "*-prod"
+    depends_on:
+      - clone kube repo


### PR DESCRIPTION
Currently we have a badly formatted script - this change corrects all of 
the formatting to be better inlined.

Currently we have a `build project` step that both builds and tests the 
project. This changes splits this between a `build project` and `test 
project` 
step that allows for better visibility in the pipeline.