### PR TITLE
HOCS-2657: change escaping implementation

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/templates/TemplateService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/templates/TemplateService.java
@@ -1,13 +1,13 @@
 package uk.gov.digital.ho.hocs.templates;
 
 import lombok.extern.slf4j.Slf4j;
+import net.logstash.logback.encoder.org.apache.commons.lang.StringEscapeUtils;
 import org.docx4j.model.datastorage.migration.VariablePrepare;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.openpackaging.parts.WordprocessingML.MainDocumentPart;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.stereotype.Service;
-import org.springframework.web.util.HtmlUtils;
 import uk.gov.digital.ho.hocs.templates.client.caseworkclient.CaseworkClient;
 import uk.gov.digital.ho.hocs.templates.client.caseworkclient.dto.AddressDto;
 import uk.gov.digital.ho.hocs.templates.client.caseworkclient.dto.CaseDataDto;
@@ -66,7 +66,7 @@ public class TemplateService {
         TeamDto team = getPrivateOfficeTeamDetails(caseUUID, caseDetails);
 
         HashMap<String, String> variables = createVariablesMap(caseDetails, primary, constituent, team);
-        variables.replaceAll((k, v) -> HtmlUtils.htmlEscape(v));
+        variables.replaceAll((k, v) -> StringEscapeUtils.escapeXml(v));
 
         InputStream templateInputStream = getTemplateAsInputStream(templateUUID);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/templates/TemplateServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/templates/TemplateServiceTest.java
@@ -97,7 +97,7 @@ public class TemplateServiceTest {
 
     private CorrespondentsDto getCorrespondents() {
         AddressDto address = new AddressDto("S1 1DJ", "1 Somewhere Street", "Somewhere", "", "");
-        CorrespondentDto primaryCorrespondent = new CorrespondentDto(PRIMARY_CORRESPONDENT_UUID, LocalDateTime.now(), "MEMBER", CASE_UUID, "Bob Smith MP", address, "", "", "ref1");
+        CorrespondentDto primaryCorrespondent = new CorrespondentDto(PRIMARY_CORRESPONDENT_UUID, LocalDateTime.now(), "MEMBER", CASE_UUID, "Thomérè Little", address, "", "", "ref1");
         CorrespondentDto constituent = new CorrespondentDto(UUID.fromString("66666666-6666-6666-6666-666666666666"), LocalDateTime.now(), "CONSTITUENT", CASE_UUID, "Bob", address, "", "", "");
         return new CorrespondentsDto(Stream.of(primaryCorrespondent, constituent).collect(Collectors.toCollection(HashSet::new)));
 


### PR DESCRIPTION
Currently we use a HTML escaping function for the variables, 
however as we use a XML library this fails. This is because é and 
some other characters are not valid XML when escaped using HTML 
these fail the replace. This change uses the Apache Commons  
`StringEscapeUtils.escapeXml` functionality to escape to the entity 
number instead of the entity code.