### PR TITLE
HOCS-3698 Fixing error where complaints templates would not download

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/templates/TemplateService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/templates/TemplateService.java
@@ -99,9 +99,12 @@ public class TemplateService {
     }
 
     private String formatDate(String unformattedDate) {
-        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd MMMM yyyy");
-        LocalDate date = LocalDate.parse(unformattedDate);
-        return date.format(dateTimeFormatter);
+        if(unformattedDate != null){
+            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd MMMM yyyy");
+            LocalDate date = LocalDate.parse(unformattedDate);
+            return date.format(dateTimeFormatter);
+        }
+        return "";
     }
 
     private InputStream getTemplateAsInputStream(UUID templateUUID) {

--- a/src/main/java/uk/gov/digital/ho/hocs/templates/TemplateService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/templates/TemplateService.java
@@ -40,6 +40,7 @@ public class TemplateService {
     private final CaseworkClient caseworkClient;
     private final InfoClient infoClient;
     private final DocumentClient documentClient;
+    private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd MMMM yyyy");
 
     @Autowired
     public TemplateService(CaseworkClient caseworkClient,
@@ -100,7 +101,6 @@ public class TemplateService {
 
     private String formatDate(String unformattedDate) {
         if(unformattedDate != null){
-            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("dd MMMM yyyy");
             LocalDate date = LocalDate.parse(unformattedDate);
             return date.format(dateTimeFormatter);
         }


### PR DESCRIPTION
This bug was caused by COMP cases having no dateOfLetter (unlike DCU cases), so this PR adds a check and returns an empty string as is done with the rest of the variables in createVariablesMap()