### PR TITLE
HOCS-3952 remove the use of the Junit4 and Retry libraries from the project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,11 +49,13 @@ dependencies {
 
 	implementation('net.logstash.logback:logstash-logback-encoder:5.3')
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
-	testImplementation('org.assertj:assertj-core')
-	testImplementation('junit:junit:4.12')
 	testImplementation('com.github.tomakehurst:wiremock-standalone:2.18.0')
 }
 
 jar {
 	enabled = false
+}
+
+test {
+	useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ dependencies {
 	implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.5'
 
 	implementation('org.springframework.boot:spring-boot-starter-web')
-	implementation('org.springframework.retry:spring-retry')
 	implementation('org.springframework.boot:spring-boot-starter-actuator')
 	implementation("org.apache.camel:camel-spring-boot-starter:2.23.0")
 	implementation('javax:javaee-api:8.0.1')

--- a/src/main/java/uk/gov/digital/ho/hocs/templates/application/RestHelper.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/templates/application/RestHelper.java
@@ -5,8 +5,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
@@ -35,14 +33,12 @@ public class RestHelper {
         this.requestData = requestData;
     }
 
-    @Retryable(maxAttemptsExpression = "${retry.maxAttempts}", backoff = @Backoff(delayExpression = "${retry.delay}"))
     public <R> R get(String serviceBaseURL, String url, Class<R> responseType) {
         log.info("RestHelper making GET request to {}{}", serviceBaseURL, url, value(LogEvent.EVENT, REST_HELPER_GET));
         ResponseEntity<R> response = restTemplate.exchange(String.format("%s%s", serviceBaseURL, url), HttpMethod.GET, new HttpEntity<>(null, createAuthHeaders()), responseType);
         return response.getBody();
     }
 
-    @Retryable(maxAttemptsExpression = "${retry.maxAttempts}", backoff = @Backoff(delayExpression = "${retry.delay}"))
     public <R> R get(String serviceBaseURL, String url, ParameterizedTypeReference<R> responseType) {
         log.info("RestHelper making GET request to {}{}", serviceBaseURL, url, value(EVENT, REST_HELPER_GET));
         ResponseEntity<R> response = restTemplate.exchange(String.format("%s%s", serviceBaseURL, url), HttpMethod.GET, new HttpEntity<>(null, createAuthHeaders()), responseType);

--- a/src/test/java/uk/gov/digital/ho/hocs/templates/TemplateResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/templates/TemplateResourceTest.java
@@ -1,10 +1,10 @@
 package uk.gov.digital.ho.hocs.templates;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TemplateResourceTest {
 
     private final UUID caseUUID = UUID.randomUUID();
@@ -24,7 +24,7 @@ public class TemplateResourceTest {
     private TemplateService templateService;
     private TemplateResource templateResource;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         templateResource = new TemplateResource(templateService);
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/templates/TemplateServiceIntTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/templates/TemplateServiceIntTest.java
@@ -5,15 +5,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.compress.utils.IOUtils;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.openpackaging.parts.WordprocessingML.MainDocumentPart;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
@@ -37,14 +38,16 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.test.web.client.MockRestServiceServer.bindTo;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@ActiveProfiles("development")
 public class TemplateServiceIntTest {
 
     private MockRestServiceServer mockService;
@@ -71,7 +74,7 @@ public class TemplateServiceIntTest {
     private final UUID TEMPLATE_UUID = UUID.fromString("22222222-2222-2222-2222-222222222222");
     private final UUID PRIMARY_CORRESPONDENT_UUID = UUID.fromString("44444444-4444-4444-4444-444444444444");
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         mockService = buildMockService(restTemplate);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/templates/TemplateServiceTROTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/templates/TemplateServiceTROTest.java
@@ -1,11 +1,11 @@
 package uk.gov.digital.ho.hocs.templates;
 
 import org.apache.commons.compress.utils.IOUtils;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.ByteArrayResource;
 import uk.gov.digital.ho.hocs.templates.client.caseworkclient.CaseworkClient;
 import uk.gov.digital.ho.hocs.templates.client.caseworkclient.dto.AddressDto;
@@ -29,7 +29,7 @@ import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TemplateServiceTROTest {
     private static final String CASE_TYPE = "TRO";
 
@@ -51,7 +51,7 @@ public class TemplateServiceTROTest {
     @Mock
     DocumentClient documentClient;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.templateService = new TemplateService(caseworkClient, infoClient, documentClient);
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/templates/TemplateServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/templates/TemplateServiceTest.java
@@ -1,11 +1,11 @@
 package uk.gov.digital.ho.hocs.templates;
 
 import org.apache.commons.compress.utils.IOUtils;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.ByteArrayResource;
 import uk.gov.digital.ho.hocs.templates.client.caseworkclient.CaseworkClient;
 import uk.gov.digital.ho.hocs.templates.client.caseworkclient.dto.AddressDto;
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TemplateServiceTest {
 
     private static final String MIN = "MIN";
@@ -52,7 +52,7 @@ public class TemplateServiceTest {
     DocumentClient documentClient;
 
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.templateService = new TemplateService(caseworkClient, infoClient, documentClient);
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/templates/application/MultiFormatLocalDateSerializerTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/templates/application/MultiFormatLocalDateSerializerTest.java
@@ -2,11 +2,11 @@ package uk.gov.digital.ho.hocs.templates.application;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
 import java.time.DateTimeException;
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class MultiFormatLocalDateSerializerTest {
 
     private MultiFormatLocalDateSerializer serializer;
@@ -27,7 +27,7 @@ public class MultiFormatLocalDateSerializerTest {
     @Mock
     DeserializationContext context;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         serializer = new MultiFormatLocalDateSerializer();
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/templates/client/caseworkclient/CaseworkClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/templates/client/caseworkclient/CaseworkClientTest.java
@@ -1,10 +1,10 @@
 package uk.gov.digital.ho.hocs.templates.client.caseworkclient;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.digital.ho.hocs.templates.application.RestHelper;
 import uk.gov.digital.ho.hocs.templates.client.caseworkclient.dto.AddressDto;
@@ -19,9 +19,10 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CaseworkClientTest {
 
     @Mock
@@ -34,7 +35,7 @@ public class CaseworkClientTest {
 
     CaseworkClient caseworkClient;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.caseworkClient = new CaseworkClient(restHelper, serviceBaseURL);
     }
@@ -63,24 +64,24 @@ public class CaseworkClientTest {
         verifyNoMoreInteractions(restHelper);
     }
 
-    @Test(expected = HttpClientErrorException.NotFound.class)
+    @Test
     public void shouldThrowEntityNotFoundExceptionWhenGetCaseData() {
 
         doThrow(HttpClientErrorException.NotFound.class).when(restHelper).get(eq(serviceBaseURL), eq(String.format("/case/%s", uuid)), eq(CaseDataDto.class));
-        caseworkClient.getCase(uuid);
+        assertThrows(HttpClientErrorException.NotFound.class, () -> caseworkClient.getCase(uuid));
 
         verify(restHelper, times(1)).get(eq(serviceBaseURL), eq(String.format("/case/%s", uuid)), eq(CaseDataDto.class));
         verifyNoMoreInteractions(restHelper);
 
     }
 
-    @Test(expected = ApplicationExceptions.EntityNotFoundException.class)
+    @Test
     public void shouldTHrowEntityNotFoundExceptionWhenGetCorrespondentsData() {
         CorrespondentsDto correspondents = new CorrespondentsDto(new HashSet<>());
 
         when(restHelper.get(eq(serviceBaseURL), eq(String.format("/case/%s/correspondent", uuid)), eq(CorrespondentsDto.class))).thenReturn(correspondents);
 
-        caseworkClient.getCorrespondents(uuid);
+        assertThrows(ApplicationExceptions.EntityNotFoundException.class, () -> caseworkClient.getCorrespondents(uuid));
 
         verify(restHelper, times(1)).get(eq(serviceBaseURL), eq(String.format("/case/%s/correspondent", uuid)), eq(CorrespondentsDto.class));
         verifyNoMoreInteractions(restHelper);

--- a/src/test/java/uk/gov/digital/ho/hocs/templates/client/documentclient/DocumentClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/templates/client/documentclient/DocumentClientTest.java
@@ -1,20 +1,21 @@
 package uk.gov.digital.ho.hocs.templates.client.documentclient;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.digital.ho.hocs.templates.application.RestHelper;
 
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class DocumentClientTest {
 
     @Mock
@@ -25,7 +26,7 @@ public class DocumentClientTest {
 
     private DocumentClient documentClient;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.documentClient = new DocumentClient(restHelper, serviceBaseURL);
     }
@@ -42,10 +43,10 @@ public class DocumentClientTest {
         verifyNoMoreInteractions(restHelper);
     }
 
-    @Test(expected = HttpClientErrorException.NotFound.class)
+    @Test
     public void shouldThrowNotFoundExceptionWhenGetTemplate() {
         doThrow(HttpClientErrorException.NotFound.class).when(restHelper).get(eq(serviceBaseURL), eq(String.format("/document/%s/file", uuid)), eq(ByteArrayResource.class));
-        documentClient.getTemplate(uuid);
+        assertThrows(HttpClientErrorException.NotFound.class, () -> documentClient.getTemplate(uuid));
 
         verify(restHelper, times(1)).get(eq(serviceBaseURL), eq(String.format("/document/%s/file", uuid)), eq(ByteArrayResource.class));
         verifyNoMoreInteractions(restHelper);

--- a/src/test/java/uk/gov/digital/ho/hocs/templates/client/infoclient/InfoClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/templates/client/infoclient/InfoClientTest.java
@@ -1,21 +1,22 @@
 package uk.gov.digital.ho.hocs.templates.client.infoclient;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.digital.ho.hocs.templates.application.RestHelper;
 import uk.gov.digital.ho.hocs.templates.client.infoclient.dto.TeamDto;
 
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class InfoClientTest {
 
     @Mock
@@ -28,7 +29,7 @@ public class InfoClientTest {
 
     private InfoClient infoClient;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.infoClient = new InfoClient(restHelper, serviceBaseURL);
     }
@@ -46,10 +47,10 @@ public class InfoClientTest {
     }
 
 
-    @Test(expected = HttpClientErrorException.NotFound.class)
+    @Test
     public void shouldThrowNotFoundExceptionWhenGetTemplate() {
         doThrow(HttpClientErrorException.NotFound.class).when(restHelper).get(eq(serviceBaseURL), eq(String.format("/team/case/%s/topic/%s/stage/%s", uuid, uuid, STAGE_TYPE)), eq(TeamDto.class));
-        infoClient.getTeamForTopicAndStage(uuid, uuid, STAGE_TYPE);
+        assertThrows(HttpClientErrorException.NotFound.class, () -> infoClient.getTeamForTopicAndStage(uuid, uuid, STAGE_TYPE));
 
         verify(restHelper, Mockito.times(1)).get(eq(serviceBaseURL), eq(String.format("/team/case/%s/topic/%s/stage/%s", uuid, uuid, STAGE_TYPE)), eq(TeamDto.class));
         verifyNoMoreInteractions(restHelper);


### PR DESCRIPTION
This commit removes the use of the Junit4 and Retry libraries from the project.