### PR TITLE
HOCS-4073 Reduce the startup probe timings

### DIFF
--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -188,9 +188,9 @@ spec:
               httpHeaders:
                 - name: X-probe
                   value: kubelet
-            initialDelaySeconds: 20
-            periodSeconds: 5
-            failureThreshold: 6
+            initialDelaySeconds: 6
+            periodSeconds: 2
+            failureThreshold: 22
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness


### PR DESCRIPTION
The service now starts inside 5 seconds, we can tighten the startup probe timings to get to a ready state quicker.