### PR TITLE
HOCS-4421: deployment uses point in time config

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,6 @@ steps:
       registry: quay.io
       repo: quay.io/ukhomeofficedigital/hocs-templates
       tags:
-        - build_${DRONE_BUILD_NUMBER}
         - ${DRONE_COMMIT_SHA}
         - branch-${DRONE_COMMIT_BRANCH/\//_}
     environment:
@@ -50,7 +49,6 @@ steps:
       registry: quay.io
       repo: quay.io/ukhomeofficedigital/hocs-templates
       tags:
-        - build_${DRONE_BUILD_NUMBER}
         - ${DRONE_COMMIT_SHA}
         - latest
     environment:
@@ -88,6 +86,11 @@ environment:
   DOCKER_HOST: tcp://docker:2375
 
 steps:
+  - name: fetch and checkout
+    image: alpine/git
+    commands:
+      - git fetch --tags
+      - git checkout $${VERSION}
 
   - name: deploy to cs-dev
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
@@ -99,7 +102,9 @@ steps:
       KUBE_TOKEN:
         from_secret: hocs_templates_cs_dev
       KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      VERSION: build_${DRONE_BUILD_NUMBER}
+      VERSION: "${DRONE_COMMIT_SHA}"
+    depends_on:
+      - fetch and checkout
     when:
       branch:
         - main
@@ -116,7 +121,9 @@ steps:
       KUBE_TOKEN:
         from_secret: hocs_templates_wcs_dev
       KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      VERSION: build_${DRONE_BUILD_NUMBER}
+      VERSION: "${DRONE_COMMIT_SHA}"
+    depends_on:
+      - fetch and checkout
     when:
       branch:
         - main
@@ -158,6 +165,7 @@ steps:
         from_secret: GITHUB_TOKEN
     depends_on:
       - wait for docker
+      - fetch and checkout
     when:
       event:
         - promote
@@ -214,6 +222,8 @@ steps:
       KUBE_TOKEN:
         from_secret: hocs_templates_${DRONE_DEPLOY_TO/-/_}
       KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+    depends_on:
+      - fetch and checkout
     when:
       event:
         - promote
@@ -232,6 +242,8 @@ steps:
       KUBE_TOKEN:
         from_secret: hocs_templates_${DRONE_DEPLOY_TO/-/_}
       KUBE_SERVER: https://kube-api-prod.prod.acp.homeoffice.gov.uk
+    depends_on:
+      - fetch and checkout
     when:
       event:
         - promote


### PR DESCRIPTION
Releases that are currently handled through the pipeline use the
kubernetes configuration at the head of main and not the point in time
for that 'version'. This change includes adding a 'fetch and checkout'
step that checks out the Git commit SHA for dev deployments and the
SemVar tag for other releases. This enables us to use the config from
that point in time.