### PR TITLE
HOCS-4695: output the deployment version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -174,7 +174,7 @@ steps:
       KUBE_TOKEN:
         from_secret: hocs_templates_cs_dev
       KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      VERSION: "${DRONE_TAG}"
+      VERSION: ${DRONE_TAG}
     depends_on:
       - clone
 
@@ -188,6 +188,6 @@ steps:
       KUBE_TOKEN:
         from_secret: hocs_templates_wcs_dev
       KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      VERSION: "${DRONE_TAG}"
+      VERSION: ${DRONE_TAG}
     depends_on:
       - clone

--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -6,6 +6,11 @@ export KUBE_SERVER=${KUBE_SERVER}
 export KUBE_TOKEN=${KUBE_TOKEN}
 export VERSION=${VERSION}
 
+echo
+echo "Deploying hocs-templates to ${ENVIRONMENT}"
+echo "Service version: ${VERSION}"
+echo
+
 if [[ ${KUBE_NAMESPACE} == *prod ]]
 then
     export MIN_REPLICAS="2"


### PR DESCRIPTION
At present when we deploy we only have the Drone API to identify the
version being applied. To support debugging of potential release issues,
this change prints out both the environment and the version to the
console on a deployment.