### PR TITLE
HOCS-4799: update build image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ trigger:
 
 steps:
   - name: test project
-    image: quay.io/ukhomeofficedigital/hocs-base-image-build
+    image: quay.io/ukhomeofficedigital/hocs-base-image-build:1.0.2
     commands:
       - ./gradlew clean build --no-daemon
 
@@ -128,7 +128,7 @@ trigger:
     - main
 steps:
   - name: test project
-    image: quay.io/ukhomeofficedigital/hocs-base-image-build
+    image: quay.io/ukhomeofficedigital/hocs-base-image-build:1.0.2
     commands:
       - ./gradlew clean build --no-daemon
 


### PR DESCRIPTION
This commit pegs the build images version within the drone pipeline to
use the latest iteration.