### PR TITLE
HOCS-4808: support tagging on support branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -126,13 +126,15 @@ trigger:
     - tag
   branch:
     - main
+    - support/*
+
 steps:
   - name: test project
     image: quay.io/ukhomeofficedigital/hocs-base-image-build:1.0.2
     commands:
       - ./gradlew clean build --no-daemon
 
-  - name: build & push latest
+  - name: build & push tag main
     image: plugins/docker
     settings:
       registry: quay.io
@@ -147,6 +149,27 @@ steps:
       DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
     depends_on:
       - test project
+    when:
+      branch:
+        - main
+
+  - name: build & push tag
+    image: plugins/docker
+    settings:
+      registry: quay.io
+      repo: quay.io/ukhomeofficedigital/hocs-templates
+      tags:
+        - ${DRONE_TAG}
+        - ${DRONE_COMMIT_SHA}
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: QUAY_ROBOT_TOKEN
+      DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
+    depends_on:
+      - test project
+    when:
+      branch:
+        - support/*
 
 ---
 kind: pipeline


### PR DESCRIPTION
To support hotfixing this change allows the for a build and tag step to
be run on support branches aswell.