### PR TITLE
HOCS-5561: Pass $JAVA_OPTS to entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY --from=builder --chown=user_hocs:group_hocs ./builder/application/ ./
 
 USER 10000
 
-ENTRYPOINT exec java org.springframework.boot.loader.JarLauncher
+ENTRYPOINT exec java $JAVA_OPTS org.springframework.boot.loader.JarLauncher


### PR DESCRIPTION
This was previously missing from the entrypoint meaning that memory and proxy settings were not being respected.