### PR TITLE
Bump docx4j version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.3'
 }
 
-def docx4jVersion = '11.4.8'
+def docx4jVersion = '11.5.0'
 def jaxbVersion = '4.0.1'
 def lombokVersion = '1.18.30'
 


### PR DESCRIPTION
https://github.com/plutext/docx4j/issues/381 latest docx template for TRO had xmlns:w16cid namespaces warnings when generating that requires 8.5/11.5 versions of docx4j to support